### PR TITLE
Track section offsets for TAC mention spans

### DIFF
--- a/tac_to_jsonl.py
+++ b/tac_to_jsonl.py
@@ -10,17 +10,32 @@ def parse_tac_xml(xml_path):
     
     # Concatenate all sections as the input text
     sections = []
+    section_offsets = {}
+    current_offset = 0
     for sec in root.findall(".//Section"):
         if sec.text:
-            sections.append(sec.text.strip())
+            sec_text = sec.text.strip()
+            sections.append(sec_text)
+            sec_id = sec.attrib.get("id") or sec.attrib.get("sec_id")
+            if sec_id is not None:
+                section_offsets[sec_id] = current_offset
+            current_offset += len(sec_text) + 2  # account for the \n\n joiner
     text = "\n\n".join(sections)
     
     mentions = []
     for m in root.findall(".//Mention"):
         mtype = m.attrib["type"]
-        starts = [int(s) for s in m.attrib["start"].split(",")]
-        lengths = [int(l) for l in m.attrib["len"].split(",")]
-        spans = [[s, min(s + l, len(text))] for s, l in zip(starts, lengths)]
+        start_vals = m.attrib["start"].split(",")
+        length_vals = m.attrib["len"].split(",")
+        sec_ids = m.attrib.get("sec_id", "").split(",")
+        if len(sec_ids) == 1 and len(start_vals) > 1:
+            sec_ids = sec_ids * len(start_vals)
+        global_starts = []
+        for s, sec_id in zip(start_vals, sec_ids):
+            base = section_offsets.get(sec_id, 0)
+            global_starts.append(base + int(s))
+        lengths = [int(l) for l in length_vals]
+        spans = [[s, min(s + l, len(text))] for s, l in zip(global_starts, lengths)]
         mentions.append({
             "id": m.attrib["id"],
             "type": mtype,


### PR DESCRIPTION
## Summary
- track each Section's starting offset when concatenating document text
- compute Mention spans using section-specific offsets so global spans align with text

## Testing
- `python tac_to_jsonl.py`
- `python -m py_compile tac_to_jsonl.py`
- `python -m py_compile validate_tac_jsonl.py`


------
https://chatgpt.com/codex/tasks/task_e_68a49d3525288328b307398b7dcbfb83