### PR TITLE
Fix section parsing to retain nested text

### DIFF
--- a/tac_to_jsonl.py
+++ b/tac_to_jsonl.py
@@ -11,9 +11,11 @@ def parse_tac_xml(xml_path):
     # Concatenate all sections as the input text
     sections = []
     for sec in root.findall(".//Section"):
-        if sec.text:
-            sections.append(sec.text.strip())
-    text = "\n\n".join(sections)
+        sec_text = ''.join(sec.itertext())
+        sections.append(sec_text)
+        if not sec_text.endswith("\n"):
+            sections.append("\n")
+    text = "".join(sections).rstrip("\n")
     
     mentions = []
     for m in root.findall(".//Mention"):


### PR DESCRIPTION
## Summary
- Preserve full section text by joining `itertext` recursively
- Build full document with original whitespace for accurate mention offsets

## Testing
- `python3 -m py_compile tac_to_jsonl.py`
- `python3 tac_to_jsonl.py`

------
https://chatgpt.com/codex/tasks/task_e_68a49d2e8d80832889e254f577d3b1e2