### PR TITLE
Fix section offset calculation in TAC XML converter

### DIFF
--- a/tac_to_jsonl.py
+++ b/tac_to_jsonl.py
@@ -14,9 +14,14 @@ def parse_tac_xml(xml_path):
     current_offset = 0
     for sec in root.findall(".//Section"):
         sec_text = ''.join(sec.itertext())
+        sec_id = sec.attrib.get("id")
+        if sec_id:
+            section_offsets[sec_id] = current_offset
         sections.append(sec_text)
+        current_offset += len(sec_text)
         if not sec_text.endswith("\n"):
             sections.append("\n")
+            current_offset += 1
     text = "".join(sections).rstrip("\n")
     
     mentions = []


### PR DESCRIPTION
## Summary
- compute and track section offsets to generate correct global spans when parsing TAC XML files

## Testing
- `python tac_to_jsonl.py`
- `python validate_tac_jsonl.py`


------
https://chatgpt.com/codex/tasks/task_e_68a4a39b40748328bdedd3c1bc3b6bf7